### PR TITLE
[Search Module] searchFields only works with local search

### DIFF
--- a/server/documents/modules/search.html.eco
+++ b/server/documents/modules/search.html.eco
@@ -464,7 +464,7 @@ type        : 'UI Module'
               ]
             </div>
           </td>
-          <td>Specify object properties inside source object which will be searched</td>
+          <td>Specify object properties inside local source object which will be searched. Does not work with remote search.</td>
         </tr>
         <tr>
           <td>hideDelay</td>


### PR DESCRIPTION
This makes it explicit that `searchFields` only works with local, and not remote, search. (from https://github.com/Semantic-Org/Semantic-UI/issues/1847#issuecomment-75377971)
